### PR TITLE
feat: add radiation data API and chart

### DIFF
--- a/api/app.mjs
+++ b/api/app.mjs
@@ -10,6 +10,7 @@ import { WebSocketServer } from "ws";
 
 import { fetchLatestData, getLatestData } from "./controllers/capteurs-controller.mjs";
 import adminRouter from "./routes/admin.mjs";
+import radiationRouter from "./routes/radiation-routes.mjs";
 
 const app = express();
 const PORT = process.env.PORT || 5002;
@@ -20,6 +21,7 @@ app.use(cors()); // Enable Cross-Origin Resource Sharing
 app.use("/api/users", userRouter); // Route for user-related requests
 app.use("/api/capteurs", capteurRouter); // Route for capteur-related requests
 app.use("/api/admin", adminRouter); // Route for admin-related requests
+app.use("/api/radiation", radiationRouter); // Route for radiation-related requests
 
 // Route for the root URL
 app.get("/", (req, res, next) => {

--- a/api/controllers/radiation-controller.mjs
+++ b/api/controllers/radiation-controller.mjs
@@ -1,0 +1,26 @@
+import asyncHandler from "express-async-handler";
+import { Radiation } from "../models/Radiation.mjs";
+
+/**
+ * Stores radiation values in the database.
+ * @param {Object} req - Express request object expecting Vbas, Vhaut and Delta in body.
+ * @param {Object} res - Express response object.
+ */
+const addRadiationData = asyncHandler(async (req, res) => {
+  const { Vbas, Vhaut, Delta } = req.body;
+  const radiation = new Radiation({ Vbas, Vhaut, Delta });
+  await radiation.save();
+  res.status(201).json(radiation);
+});
+
+/**
+ * Retrieves all radiation data sorted by timestamp.
+ * @param {Object} req - Express request object.
+ * @param {Object} res - Express response object.
+ */
+const getRadiationData = asyncHandler(async (req, res) => {
+  const data = await Radiation.find().sort({ timestamp: 1 });
+  res.status(200).json(data);
+});
+
+export { addRadiationData, getRadiationData };

--- a/api/models/Radiation.mjs
+++ b/api/models/Radiation.mjs
@@ -1,0 +1,13 @@
+import mongoose from "mongoose";
+const { Schema } = mongoose;
+
+const radiationSchema = new Schema({
+  Vbas: { type: Number, required: true },
+  Vhaut: { type: Number, required: true },
+  Delta: { type: Number, required: true },
+  timestamp: { type: Date, default: Date.now }
+}, { collection: 'radiations' });
+
+const Radiation = mongoose.model("radiation", radiationSchema);
+
+export { Radiation };

--- a/api/routes/radiation-routes.mjs
+++ b/api/routes/radiation-routes.mjs
@@ -1,0 +1,10 @@
+import express from "express";
+import { addRadiationData, getRadiationData } from "../controllers/radiation-controller.mjs";
+import { verifyToken, authorization, isAdmin } from "../middlewares/authorization.mjs";
+
+const radiationRouter = express.Router();
+
+radiationRouter.post("/", verifyToken, authorization, isAdmin, addRadiationData);
+radiationRouter.get("/", verifyToken, authorization, isAdmin, getRadiationData);
+
+export default radiationRouter;


### PR DESCRIPTION
## Summary
- add radiation schema and controllers for storing Vbas/Vhaut/Delta values
- expose new `/api/radiation` endpoints and wire into server
- fetch and post radiation data on dashboard to render dynamic chart

## Testing
- `npm test` (api)
- `npm test` (frontend) *(fails: Missing script)*
- `npm run lint` *(fails: requires configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c70a3456648325a558605735af0a9f