### PR TITLE
feat: add Arduino config and reading APIs

### DIFF
--- a/api/app.mjs
+++ b/api/app.mjs
@@ -11,6 +11,7 @@ import { WebSocketServer } from "ws";
 import { fetchLatestData, getLatestData } from "./controllers/capteurs-controller.mjs";
 import adminRouter from "./routes/admin.mjs";
 import radiationRouter from "./routes/radiation-routes.mjs";
+import arduinoRouter from "./routes/arduino-routes.mjs";
 
 const app = express();
 const PORT = process.env.PORT || 5002;
@@ -22,6 +23,7 @@ app.use("/api/users", userRouter); // Route for user-related requests
 app.use("/api/capteurs", capteurRouter); // Route for capteur-related requests
 app.use("/api/admin", adminRouter); // Route for admin-related requests
 app.use("/api/radiation", radiationRouter); // Route for radiation-related requests
+app.use("/api/v1", arduinoRouter); // Routes for Arduino config and readings
 
 // Route for the root URL
 app.get("/", (req, res, next) => {

--- a/api/controllers/arduino-controller.mjs
+++ b/api/controllers/arduino-controller.mjs
@@ -1,0 +1,30 @@
+import { ArduinoConfig } from "../models/arduino-config.mjs";
+import { ArduinoReading } from "../models/arduino-reading.mjs";
+
+const getConfig = async (req, res) => {
+  try {
+    const config = await ArduinoConfig.findOne().sort({ createdAt: -1 }).lean();
+    if (!config) {
+      return res.json({ Vb: 0, Vh: 0, delta: 0 });
+    }
+    res.json({ Vb: config.Vb, Vh: config.Vh, delta: config.delta });
+  } catch (error) {
+    res.status(500).json({ message: "Error retrieving config", error });
+  }
+};
+
+const postComptage = async (req, res) => {
+  try {
+    const { comptage } = req.body;
+    if (comptage === undefined) {
+      return res.status(400).json({ message: "comptage is required" });
+    }
+    const reading = new ArduinoReading({ comptage });
+    await reading.save();
+    res.status(201).json(reading);
+  } catch (error) {
+    res.status(500).json({ message: "Error saving data", error });
+  }
+};
+
+export { getConfig, postComptage };

--- a/api/models/arduino-config.mjs
+++ b/api/models/arduino-config.mjs
@@ -1,0 +1,14 @@
+import mongoose from "mongoose";
+
+const configSchema = new mongoose.Schema(
+  {
+    Vb: { type: Number, required: true },
+    Vh: { type: Number, required: true },
+    delta: { type: Number, required: true }
+  },
+  { collection: 'arduino_configs', timestamps: true }
+);
+
+const ArduinoConfig = mongoose.model('arduino_config', configSchema);
+
+export { ArduinoConfig };

--- a/api/models/arduino-reading.mjs
+++ b/api/models/arduino-reading.mjs
@@ -1,0 +1,13 @@
+import mongoose from "mongoose";
+
+const readingSchema = new mongoose.Schema(
+  {
+    comptage: { type: Number, required: true },
+    timestamp: { type: Date, default: Date.now }
+  },
+  { collection: 'arduino_readings' }
+);
+
+const ArduinoReading = mongoose.model('arduino_reading', readingSchema);
+
+export { ArduinoReading };

--- a/api/routes/arduino-routes.mjs
+++ b/api/routes/arduino-routes.mjs
@@ -1,0 +1,9 @@
+import express from "express";
+import { getConfig, postComptage } from "../controllers/arduino-controller.mjs";
+
+const arduinoRouter = express.Router();
+
+arduinoRouter.get("/config", getConfig);
+arduinoRouter.post("/readings", postComptage);
+
+export default arduinoRouter;


### PR DESCRIPTION
## Summary
- expose `/api/v1/config` to deliver Vb, Vh and delta values
- add `/api/v1/readings` endpoint to store Arduino comptage data in MongoDB
- wire new routes into Express application

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c7160fd2308325adeaa76f27de55a5