### PR TITLE
Use comptage data for radiation chart

### DIFF
--- a/api/controllers/arduino-controller.mjs
+++ b/api/controllers/arduino-controller.mjs
@@ -27,4 +27,15 @@ const postComptage = async (req, res) => {
   }
 };
 
-export { getConfig, postComptage };
+
+const getComptage = async (req, res) => {
+  try {
+    const readings = await ArduinoReading.find().sort({ timestamp: 1 });
+    res.json(readings);
+  } catch (error) {
+    res.status(500).json({ message: "Error retrieving data", error });
+  }
+};
+
+
+export { getConfig, postComptage, getComptage };

--- a/api/routes/arduino-routes.mjs
+++ b/api/routes/arduino-routes.mjs
@@ -1,9 +1,10 @@
 import express from "express";
-import { getConfig, postComptage } from "../controllers/arduino-controller.mjs";
+import { getConfig, postComptage, getComptage } from "../controllers/arduino-controller.mjs";
 
 const arduinoRouter = express.Router();
 
 arduinoRouter.get("/config", getConfig);
+arduinoRouter.get("/readings", getComptage);
 arduinoRouter.post("/readings", postComptage);
 
 export default arduinoRouter;

--- a/frontend/src/app/radiation/page.jsx
+++ b/frontend/src/app/radiation/page.jsx
@@ -26,7 +26,7 @@ export default function RadiationDash() {
 
   const fetchData = async () => {
     try {
-      const response = await fetch("http://localhost:5002/api/radiation", {
+      const response = await fetch("http://localhost:5002/api/arduino/readings", {
         headers: { Authorization: `Bearer ${token}` },
       });
       const data = await response.json();
@@ -80,7 +80,7 @@ export default function RadiationDash() {
   const chartData = [
     {
       x: radiationData.map((d) => new Date(d.timestamp).toLocaleTimeString()),
-      y: radiationData.map((d) => d.Delta),
+      y: radiationData.map((d) => d.comptage),
       type: "scatter",
       mode: "lines+markers",
       marker: { color: "green" },


### PR DESCRIPTION
## Summary
- Add `getComptage` controller and route to serve Arduino comptage readings
- Switch radiation dashboard chart to fetch and plot comptage values

## Testing
- `npm test` (api) *(fails: /usr/bin/npm: No such file or directory)*
- `npm test` (frontend) *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f74fca7883258d0bd68e0cc3ac83