### PR TITLE
feat: stream radiation data via websocket

### DIFF
--- a/frontend/src/app/radiation/page.jsx
+++ b/frontend/src/app/radiation/page.jsx
@@ -74,6 +74,35 @@ export default function RadiationDash() {
 
   useEffect(() => {
     fetchData();
+
+    const socket = new WebSocket(
+      "ws://213.199.35.129:5002/api/v1/readings"
+    );
+
+    socket.onopen = () => {
+      console.log("WebSocket connection established");
+    };
+
+    socket.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        setRadiationData((prev) => [...prev, data]);
+      } catch (err) {
+        console.error("Error parsing message:", err);
+      }
+    };
+
+    socket.onerror = (error) => {
+      console.error("WebSocket error:", error);
+    };
+
+    socket.onclose = () => {
+      console.log("WebSocket connection closed");
+    };
+
+    return () => {
+      socket.close();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## Summary
- connect to radiation readings over WebSocket

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68c81fac2cd48325825f4205d468a063