### PR TITLE
Update radiation dashboard API wiring

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,6 +20,25 @@ You can start editing the page by modifying `app/page.js`. The page auto-updates
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
 
+## Radiation dashboard configuration
+
+The radiation dashboard consumes two backend endpoints:
+
+- `GET /api/v1/readings` (`http://213.199.35.129:5002/api/v1/readings`) for live radiation counts displayed on the chart.
+- `POST /api/radiation` (`http://213.199.35.129:5002/api/radiation`) to store the Vbas, Vhaut and Delta values.
+
+Set the following environment variables before running the frontend so the dashboard can reach these services in each environment:
+
+```bash
+# WebSocket stream that pushes the most recent reading every few seconds
+NEXT_PUBLIC_WS_URL=wss://yourdomain/ws
+
+# Base URL for REST APIs (defaults to http://213.199.35.129:5002 when unset)
+NEXT_PUBLIC_API_BASE_URL=http://213.199.35.129:5002
+```
+
+For local development you can point `NEXT_PUBLIC_API_BASE_URL` to `http://localhost:5002` while keeping a matching WebSocket URL (for example `ws://localhost:5002`).
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:
@@ -34,6 +53,4 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
-Test change in frontend
-This is a test change in README.md.
-This is a test change in README.md.
+


### PR DESCRIPTION
## Summary
- point the radiation dashboard at the production `/api/v1/readings` feed and `/api/radiation` writer through a configurable base URL while keeping WebSocket streaming behind `NEXT_PUBLIC_WS_URL`
- add client-side validation, loading feedback and toast messaging for pushing Vbas/Vhaut/Delta values via the authenticated REST endpoint
- document the required endpoints and environment variables for the radiation dashboard in the frontend README

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c94a0a23b08325a82a8e7960d1a3e6